### PR TITLE
Update code to be compatible with maven enforcer plugin 3.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,12 +21,12 @@ as described [here](https://en.wikipedia.org/wiki/Java_class_file#General_layout
 <plugin>
     <groupId>org.apache.maven.plugins</groupId>
     <artifactId>maven-enforcer-plugin</artifactId>
-    <version>3.0.0-M1</version>
+    <version>3.0.0</version>
     <dependencies>
         <dependency>
             <groupId>org.owasp.maven.enforcer</groupId>
             <artifactId>class-file-format-rule</artifactId>
-            <version>1.0.0</version>
+            <version>2.0.0</version>
         </dependency>
     </dependencies>
     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
     <modelVersion>4.0.0</modelVersion>
     <groupId>org.owasp.maven.enforcer</groupId>
     <artifactId>class-file-format-rule</artifactId>
-    <version>1.0.1</version>
+    <version>2.0.0-SNAPSHOT</version>
     <name>class-file-format-rule</name>
     <packaging>jar</packaging>
     <description>A maven-enforcer rule that ensures dependencies do not exceed the required class file format required by
@@ -68,14 +68,14 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <api.version>3.0.0-M1</api.version>
-        <maven.version>3.5.2</maven.version>
+        <api.version>3.0.0</api.version>
+        <maven.version>3.1.0</maven.version>
         <maven.project.version>2.2.1</maven.project.version>
         <junit.version>4.13.1</junit.version>
         <hamcrest-core.version>1.3</hamcrest-core.version>
         <!-- upgrading beyond 2.2 requires reworking the dependency resolution -->
-        <maven-dependency-tree.version>2.2</maven-dependency-tree.version>
-        <maven-artifact-transfer.version>0.9.1</maven-artifact-transfer.version>
+        <maven-dependency-tree.version>3.1.0</maven-dependency-tree.version>
+        <maven-artifact-transfer.version>0.13.1</maven-artifact-transfer.version>
     </properties>
     <build>	
         <plugins>


### PR DESCRIPTION
Fixes #4 

Updated the code to work with dependency-tree 3.1.0 so that it will work for maven enforcer plugin 3.0.0.

Lowered maven version to 3.1.0 to be in line with Maven's current policy of keeping their plugins compatible with maven 3.1 upwards.
Updated the documentation to show usage with maven-enforcer-plugin 3.0.0 as that is the minimum version to use to be compatible.